### PR TITLE
bugfix of writing of process data and parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Release 2.1.1
+
+### Bugfixes
+writing of process data and parameters is available again
+
 ## Release 2.1.0
 
 ### New features

--- a/CSK_Module_MultiIOLinkSMI/project.mf.xml
+++ b/CSK_Module_MultiIOLinkSMI/project.mf.xml
@@ -1056,7 +1056,7 @@ Provide IOLink data via event.</desc>
             </crown>
         </crown>
         <meta key="author">SICK AG</meta>
-        <meta key="version">2.1.0</meta>
+        <meta key="version">2.1.1</meta>
         <meta key="priority">low</meta>
         <meta key="copy-protected">false</meta>
         <meta key="read-protected">false</meta>

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Tested on
 
 |Device|Firmware version|Module version|
 |--|--|--|
+|SIM1012|V2.4.2|V2.1.1|
 |SIM1012|V2.4.2|V2.1.0|
 |SIM1012|V2.4.2|V2.0.0|
 |SICK AppEngine|V1.7.0|V2.0.0|

--- a/docu/CSK_Module_MultiIOLinkSMI.html
+++ b/docu/CSK_Module_MultiIOLinkSMI.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.12">
 <meta name="author" content="SICK AG">
-<title>Documentation - CSK_Module_MultiIOLinkSMI 2.1.0</title>
+<title>Documentation - CSK_Module_MultiIOLinkSMI 2.1.1</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <style>
 /* Stylesheet for CodeRay to match GitHub theme | MIT License | http://foundation.zurb.com */
@@ -615,10 +615,10 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>Documentation - CSK_Module_MultiIOLinkSMI 2.1.0</h1>
+<h1>Documentation - CSK_Module_MultiIOLinkSMI 2.1.1</h1>
 <div class="details">
 <span id="author" class="author">SICK AG</span><br>
-<span id="revnumber">version 2.1.0,</span>
+<span id="revnumber">version 2.1.1,</span>
 <span id="revdate">2025-01-22</span>
 </div>
 <div id="toc" class="toc2">
@@ -860,7 +860,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Version</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2.1.0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2.1.1</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Date</p></th>
@@ -10048,7 +10048,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </div>
 <div id="footer">
 <div id="footer-text">
-Version 2.1.0<br>
+Version 2.1.1<br>
 Last updated 2025-01-22 12:19:50 +0100
 </div>
 </div>


### PR DESCRIPTION
# Version 2.1.1

## Bugfix

### writing of process data and parameters is available again

## Following tasks were checked

- [x] Module is coded and structured according to the "Developing guideline for modules" described within the CSK documentation
- [x] All functions/events/parameters are documented within the manifest documentation
- [x] The manifest description of the main CROWN includes main information about the purpose of the module and how to use it in general
- [x] API docu based on the manifest was created and stored within the "docu"-folder of the repository
- [x] Internal LUA code documentation exists for variables and non served functions
- [x] All relevant infos are logged via the SharedLogger 'ModuleLogger'
- [x] Module supports persistent data feature based on 'CSK_Module_PersistentData'
- [x] Module supports user management based on 'CSK_Module_UserManagement'
- [x] No open "ToDos" within the code or at least clearly explained comments why they exist...
- [x] "Version" key in app manifest was updated following semantic versioning (and use '0.x.y' for test / experimental modules which are not yet ready to be officially released)
- [x] Meaningful IDs used for UI elements
- [x] Module was tested on an AppSpace device (at least on SICK AppEngine) with no error message
- [x] README.md is up to date (incl. info of device + firmware the module was tested with)
- [x] CHANGELOG.md is up to date
